### PR TITLE
[config] Use valid provider name for the OpenFaas CLI

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
 
 functions:


### PR DESCRIPTION
Seems like `faas` isn't supported. 
```bash
❯ faas build -f stack.yml                                                 
['openfaas'] is the only valid "provider.name" for the OpenFaaS CLI, but you gave: faas
```